### PR TITLE
Various fixes and enhancements

### DIFF
--- a/README
+++ b/README
@@ -5,7 +5,7 @@ raspberry pi HX711 weight scale interface
 -----------------------------------------
 
 this thing interfaces with 24-Bit Analog-to-Digital Converter (ADC) for Weigh Scales
-http://www.dfrobot.com/image/data/SEN0160/HX711_english.pdf
+https://github.com/sparkfun/HX711-Load-Cell-Amplifier/blob/master/datasheets/hx711_english.pdf
 
 http://www.amazon.com/SMAKN-Weighing-Dual-channel-Conversion-Shieding/dp/B00FVGRZ42 = $10
 

--- a/hx711.c
+++ b/hx711.c
@@ -208,8 +208,8 @@ unsigned long read_cnt(long offset, int argc) {
 
 
 if (argc < 2 ) {
- for (i=32;i;i--) {
-   printf("%d ", ((count-offset) & ( 1 << i )) > 0 );
+  for (i=31;i>=0;i--) {
+   printf("%d ", ((count-offset) & ( 1 << i )) != 0 );
   }
 
   printf("n: %10d     -  ", count - offset);

--- a/hx711.c
+++ b/hx711.c
@@ -172,17 +172,17 @@ unsigned long read_cnt(long offset, int argc) {
 
   for(i=0;i<24	; i++) {
 	SCK_ON;
+        count = count << 1;
 	b++;
 	b++;
 	b++;
 	b++;
-        if (DT_R > 0 ) { count++; }
         SCK_OFF;
 	b++;
 	b++;
-	b++;
-	b++;
-        count = count << 1;
+        if (DT_R > 0 ) { count++; }
+//	b++;
+//	b++;
   }
 
 


### PR DESCRIPTION
The binary representation of the measured values is wrong (right shifted 1 bit):

```
root@bare-rasberripi:~/hx711# ./hx711
0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 0 1 1 1 1 1 1 0 0 n:       7672     -
```

This patch formats it like this (7672 = 1110111111000):

```
root@bare-rasberripi:~/hx711# ./hx711
0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 0 1 1 1 1 1 1 0 0 0 n:       7672     -
```

Please see my fork (https://github.com/hn/hx711) for more enhancements and features.
